### PR TITLE
fix(ui): fix ShinyText readability in light theme

### DIFF
--- a/src/components/ShinyText.css
+++ b/src/components/ShinyText.css
@@ -1,3 +1,9 @@
 .shiny-text {
   display: inline-block;
 }
+
+/* Light theme: override to dark colors so text is readable on light backgrounds */
+:root.light .shiny-text {
+  --shiny-color: #374151 !important;
+  --shiny-shine-color: #111827 !important;
+}

--- a/src/components/ShinyText.tsx
+++ b/src/components/ShinyText.tsx
@@ -1,4 +1,4 @@
-import { useState, useCallback, useEffect, useRef } from 'react';
+import React, { useState, useCallback, useEffect, useRef } from 'react';
 import { motion, useMotionValue, useAnimationFrame, useTransform } from 'framer-motion';
 import './ShinyText.css';
 
@@ -102,12 +102,14 @@ const ShinyText = ({
   }, [pauseOnHover]);
 
   const gradientStyle = {
-    backgroundImage: `linear-gradient(${spread}deg, ${color} 0%, ${color} 35%, ${shineColor} 50%, ${color} 65%, ${color} 100%)`,
+    '--shiny-color': color,
+    '--shiny-shine-color': shineColor,
+    backgroundImage: `linear-gradient(${spread}deg, var(--shiny-color) 0%, var(--shiny-color) 35%, var(--shiny-shine-color) 50%, var(--shiny-color) 65%, var(--shiny-color) 100%)`,
     backgroundSize: '200% auto',
     WebkitBackgroundClip: 'text' as const,
     backgroundClip: 'text' as const,
     WebkitTextFillColor: 'transparent' as const
-  };
+  } as React.CSSProperties;
 
   return (
     <motion.span


### PR DESCRIPTION
## Summary

- ShinyText gradient colors are now driven by CSS custom properties (`--shiny-color`, `--shiny-shine-color`) instead of hardcoded hex values passed from props
- Added a `:root.light` override in `ShinyText.css` that switches the base color to dark grey (`#374151`) and the shine to near-black (`#111827`)
- Dark theme is completely unaffected
